### PR TITLE
Add space between socket path and -a

### DIFF
--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -13,7 +13,7 @@ if @udp_port
   result << '-U ' + @udp_port.to_s
 end
 if @unix_socket
-  result << '-s ' + @unix_socket.to_s + '-a 0755 '
+  result << '-s ' + @unix_socket.to_s + ' -a 0755 '
 end
 if @item_size
   result << '-I ' + @item_size.to_s


### PR DESCRIPTION
I was excited to see your pull request implemented functionality I needed, but it doesn't quite work right on my CentOS system.  I get something like this:

```
-s /var/run/memcached/memcached.sock-a 0755
```